### PR TITLE
doc: add example link for sideline-eldoc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Here is a list of supported commands:
 * [sideline-flycheck](https://github.com/jcs-elpa/sideline-flycheck)
 * [sideline-flymake](https://github.com/emacs-sideline/sideline-flymake)
 * [sideline-lsp](https://github.com/jcs-elpa/sideline-lsp)
+* [sideline-eldoc](https://github.com/ginqi7/sideline-eldoc)
 
 ## Contribute
 


### PR DESCRIPTION
add example link for sideline-eldoc.