### PR TITLE
Fix text align for `buffer-face-mode`

### DIFF
--- a/sideline.el
+++ b/sideline.el
@@ -303,22 +303,22 @@
   "Align sideline STR from the right of the window.
 
 Argument OFFSET is additional calculation from the right alignment."
-  (list (+
-         ;; If the sideline text is displayed without at least 1 pixel gap from the right fringe and
-         ;; overflow-newline-into-fringe is not true, emacs will line wrap it.
-         (if (and (display-graphic-p)
-                  (> (nth 1 (window-fringes)) 0)
-                  (not overflow-newline-into-fringe))
-             1
-           0)
-         (* (window-font-width)
-            (+ offset
-               (if (display-graphic-p)
-                   ;; If right fringe deactivated add 1 offset
-                   (if (= 0 (nth 1 (window-fringes))) 1 0)
-                 1)
-               (length str)))
-         )))
+  (let ((graphic-p (display-graphic-p))
+        (fringes (window-fringes)))
+    (list (+
+           ;; If the sideline text is displayed without at least 1 pixel gap from the right fringe and
+           ;; overflow-newline-into-fringe is not true, emacs will line wrap it.
+           (if (and graphic-p
+                    (> (nth 1 fringes) 0)
+                    (not overflow-newline-into-fringe))
+               1
+             0)
+           (* (window-font-width)
+              (+ offset (if graphic-p
+                            ;; If right fringe deactivated add 1 offset
+                            (if (= 0 (nth 1 fringes)) 1 0)
+                          1)
+                 (sideline--str-len str)))))))
 
 (defun sideline--get-line ()
   "Return current line."

--- a/sideline.el
+++ b/sideline.el
@@ -302,7 +302,7 @@
 (defun sideline--align-right (str offset)
   "Align sideline STR from the right of the window.
 
- Argument OFFSET is additional calculation from the right alignment."
+Argument OFFSET is additional calculation from the right alignment."
   (list (+
          ;; If the sideline text is displayed without at least 1 pixel gap from the right fringe and
          ;; overflow-newline-into-fringe is not true, emacs will line wrap it.
@@ -312,11 +312,13 @@
              1
            0)
          (* (window-font-width)
-            (+ offset (if (display-graphic-p)
-                          ;; If right fringe deactivated add 1 offset
-                          (if (= 0 (nth 1 (window-fringes))) 1 0)
-                        1)))
-         (sideline--string-pixel-width str))))
+            (+ offset
+               (if (display-graphic-p)
+                   ;; If right fringe deactivated add 1 offset
+                   (if (= 0 (nth 1 (window-fringes))) 1 0)
+                 1)
+               (length str)))
+         )))
 
 (defun sideline--get-line ()
   "Return current line."


### PR DESCRIPTION
When we use `buffer-face-mode` and set different font other than the default font, the text align of sideline is incorrect, like this:
<img width="2032" alt="image" src="https://github.com/emacs-sideline/sideline/assets/17001575/570b08d5-634d-4683-9bf3-dba7482cf8fb">

After this fix, it would looks like:
<img width="2032" alt="image" src="https://github.com/emacs-sideline/sideline/assets/17001575/81f331aa-0068-4381-abd8-afa5d1fad1fb">

See also: https://github.com/emacs-lsp/lsp-ui/issues/184
