### PR TITLE
Fix right align with variable width fonts

### DIFF
--- a/sideline.el
+++ b/sideline.el
@@ -256,11 +256,8 @@ which respect the `face-remapping-alist'."
         (car (buffer-text-pixel-size nil nil t))))))
 
 (defun sideline--str-len (str)
-  "Calculate STR in pixel width."
-  (let ((width (window-font-width))
-        (len (sideline--string-pixel-width str)))
-    (+ (/ len width)
-       (if (zerop (% len width)) 0 1))))  ; add one if exceeed
+  "Calculate STR length."
+  (length str))
 
 (defun sideline--kill-timer (timer)
   "Kill TIMER."


### PR DESCRIPTION
When fixing #20 , we use current window's font width to calculate the string width, but for variable width fonts, which usually used in `variable-pitch-mode`, this will cause error.

Whereas emacs's built-in `string-pixel-width` do not respect the face remapping, which cause wrong string width when use `buffer-face-mode`.

This pr mixed the @gustavotcabral 's patch and emac's built-in `string-pixel-width` to directly get the correct string width.

This fix is not that heavy because we are doing almost the same thing as emac's built-in `string-pixel-width`.

Some screenshots after fix:
<img width="2032" alt="image" src="https://github.com/emacs-sideline/sideline/assets/17001575/4c4c66f4-c855-44b2-a537-1efe3b69c43e">
<img width="2032" alt="image" src="https://github.com/emacs-sideline/sideline/assets/17001575/c446ae62-5a91-4225-ae1c-a8afd064f5c2">

