### PR TITLE
Truncate long lines

### DIFF
--- a/sideline.el
+++ b/sideline.el
@@ -92,6 +92,11 @@
   :type 'number
   :group 'sideline)
 
+(defcustom sideline-truncate-suffix "..."
+  "Truncation suffix."
+  :type 'string
+  :group 'sideline)
+
 (defface sideline-default
   '((((background light)) :foreground "DarkOrange")
     (t :foreground "yellow"))
@@ -600,8 +605,17 @@ FACE, NAME, ON-LEFT, and ORDER for details."
 
     (when sideline-truncate
       (let* ((win-width (sideline--render-data :win-width))
-             (used-space (- pos-start occ-pt)))
-        (setq str (truncate-string-to-width str (- win-width used-space)))))
+            (used-space (- pos-start occ-pt))
+            (available-space (1+ (- win-width used-space)))
+            (suffix nil))
+        (when (and sideline-truncate-suffix
+                   (> available-space (length sideline-truncate-suffix)))
+          (setq suffix (copy-sequence sideline-truncate-suffix))
+          (set-text-properties 0 (length suffix)
+                               (text-properties-at (1- (length str)) str)
+                               suffix))
+        (setq str (truncate-string-to-width str available-space 0 nil suffix))))
+
     ;; Create overlay
     (let* ((len-str (length str))
            (empty-ln (= pos-start pos-end))

--- a/sideline.el
+++ b/sideline.el
@@ -83,10 +83,13 @@
   :group 'sideline)
 
 (defcustom sideline-truncate t
-  "Truncate sideline if the line width are wider than the window width.
-
-Selected lines need to have at least 50% available space."
+  "Truncate sideline if the line width are wider than the window width."
   :type 'boolean
+  :group 'sideline)
+
+(defcustom sideline-truncate-min-available-space-ratio 0.5
+  "Minimum available space to allow truncation."
+  :type 'number
   :group 'sideline)
 
 (defface sideline-default
@@ -428,7 +431,8 @@ calculate to the right side."
         (cond ((or sideline-force-display-if-exceeds
                    (<= str-len (- column-end pos-end))
                    (and sideline-truncate
-                        (< (/ win-width 2) (- column-end pos-end))))
+                        (< (* win-width sideline-truncate-min-available-space-ratio)
+                           (- column-end pos-end))))
                (cons column-end pos-end))))))))
 
 (defun sideline--find-line (str-len on-left &optional direction exceeded)
@@ -595,8 +599,9 @@ FACE, NAME, ON-LEFT, and ORDER for details."
              title)))
 
     (when sideline-truncate
-      (let* ((win-width (sideline--render-data :win-width)))
-        (setq str (truncate-string-to-width str (- win-width (- pos-start occ-pt))))))
+      (let* ((win-width (sideline--render-data :win-width))
+             (used-space (- pos-start occ-pt)))
+        (setq str (truncate-string-to-width str (- win-width used-space)))))
     ;; Create overlay
     (let* ((len-str (length str))
            (empty-ln (= pos-start pos-end))

--- a/sideline.el
+++ b/sideline.el
@@ -82,7 +82,7 @@
   :type 'boolean
   :group 'sideline)
 
-(defcustom sideline-truncate t
+(defcustom sideline-truncate nil
   "Truncate sideline if the line width are wider than the window width."
   :type 'boolean
   :group 'sideline)


### PR DESCRIPTION
Add a setting to allow truncation. Fixes #24 (see latest comment)

Truncation is available on lines that have at least `sideline-truncate-min-available-space-ratio` of available space (50% by default).
The minium available space check is made to avoid the case where there is very few space available on the next line. The message would be almost non visible.

We could also find the longest line if the message doesn't fit but that seemed a bit too complicated to implement, and this seems to work well.
WDYT?